### PR TITLE
Use gemspec directive in Gemfile to avoid duplicating dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
-# Gemfile
 # frozen_string_literal: true
 source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-gem 'openssl' if RUBY_VERSION < '2.5'
-gem 'base64'
-gem 'rspec'
+gemspec


### PR DESCRIPTION
The Gemfile listed base64, rspec and openssl by hand, duplicating the dependencies already declared in the gemspec. This risked version drift between the two files (e.g. the Gemfile pulled base64 0.3.0 while the gemspec pins ~> 0.1.0). Delegating to `gemspec` makes the gemspec the single source of truth for runtime and development dependencies.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
