### PR TITLE
Loosen base64 dependency constraint to >= 0.1.0

### DIFF
--- a/amazon-pay-api-sdk-ruby.gemspec
+++ b/amazon-pay-api-sdk-ruby.gemspec
@@ -14,6 +14,6 @@ Gem::Specification.new do |s|
 
   # Add dependencies
   s.add_dependency 'openssl', '< 2.5' if RUBY_VERSION < '2.5'
-  s.add_dependency 'base64', '~> 0.1.0'
+  s.add_dependency 'base64', '>= 0.1.0'
   s.add_development_dependency 'rspec', '~> 3.0'
 end


### PR DESCRIPTION
The `~> 0.1.0` constraint capped base64 below 0.2.0, unnecessarily excluding newer releases (0.2.x, 0.3.x) even though the Base64 API this SDK relies on is stable across them. Relaxing to `>= 0.1.0` lets host applications resolve a wider range of versions and avoids conflicts with other gems that require a newer base64.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
